### PR TITLE
Revert "Set meta description for the main page."

### DIFF
--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -11,16 +11,7 @@ export default new Router({
     {
       path: '/',
       name: 'github',
-      component: index,
-      meta: {
-        title: 'Linux Kernel CVE Tracker',
-        metaTags: [
-          {
-            name: 'description',
-            content: 'Security Tracker for the Linux Kernel. Provides details, fixed versions, and CVSS scores for CVEs affecting the Linux Kernel.'
-          }
-        ]
-      }
+      component: index
     },
     {
       path: '/streams/:stream_id',


### PR DESCRIPTION
Reverts nluedtke/linux_kernel_cves#93

No meta description landed on staging. 